### PR TITLE
feat: Add basic key-value pair field support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,10 @@ readme = "README.md"
 rust-version = "1.56"
 
 [features]
-default = ["std"]
+default = ["std", "kv"]
 std = ["slog/std"]
+# Enables serialization of slog key-value pairs to a constructed field, `slog.fields`
+kv = []
 
 [dependencies]
 once_cell = "1.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ readme = "README.md"
 rust-version = "1.56"
 
 [features]
-default = ["std", "kv"]
+default = ["std"]
 std = ["slog/std"]
-# Enables serialization of slog key-value pairs to a constructed field, `slog.fields`
+# Enables serialization of slog key-value pairs to a constructed field, `slog.kv`
 kv = []
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Use when a library uses `slog` but your application uses `tracing`.
 
 Heavily inspired by [tracing-log](https://github.com/tokio-rs/tracing/tree/60c60bef62972e447414a748a95b31ff9027165b/tracing-log).
 
-Specifically, the emitted log entries include the custom fields `slog.target`, `slog.module_path`, `slog.file`, `slog.line`, and `slog.column` with corresponding values from the slog call site. A field `slog.fields` will contain a comma-separated list of the possible [key value pairs](https://docs.rs/slog/latest/slog/trait.KV.html) supported in `slog` logging macros if the `kv` feature is enabled.
+Specifically, the emitted log entries include the custom fields `slog.target`, `slog.module_path`, `slog.file`, `slog.line`, and `slog.column` with corresponding values from the slog call site. A field `slog.kv` will contain a comma-separated list of the possible [key value pairs](https://docs.rs/slog/latest/slog/trait.KV.html) supported in `slog` logging macros if the `kv` feature is enabled.
 
 
 Note that the "native" `filename` and `line_number` metadata attributes will never be available (and `target` will always be `slog`). This is due to the fact that `tracing` requires static metadata constructed at the original call site. The `tracing-log` adapter does provide these due to explicit support in `tracing`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Use when a library uses `slog` but your application uses `tracing`.
 
 Heavily inspired by [tracing-log](https://github.com/tokio-rs/tracing/tree/60c60bef62972e447414a748a95b31ff9027165b/tracing-log).
 
-Specifically, the emitted log entries include the custom fields `slog.target`, `slog.module_path`, `slog.file`, `slog.line`, and `slog.column` with corresponding values from the slog call site. A field `slog.fields` will contain a comma-separated list of the possible [key value pairs](https://docs.rs/slog/latest/slog/trait.KV.html) supported in `slog` logging macros.
+Specifically, the emitted log entries include the custom fields `slog.target`, `slog.module_path`, `slog.file`, `slog.line`, and `slog.column` with corresponding values from the slog call site. A field `slog.fields` will contain a comma-separated list of the possible [key value pairs](https://docs.rs/slog/latest/slog/trait.KV.html) supported in `slog` logging macros if the `kv` feature is enabled.
 
 
 Note that the "native" `filename` and `line_number` metadata attributes will never be available (and `target` will always be `slog`). This is due to the fact that `tracing` requires static metadata constructed at the original call site. The `tracing-log` adapter does provide these due to explicit support in `tracing`.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Use when a library uses `slog` but your application uses `tracing`.
 
 Heavily inspired by [tracing-log](https://github.com/tokio-rs/tracing/tree/60c60bef62972e447414a748a95b31ff9027165b/tracing-log).
 
-Specifically, the emitted log entries include the custom fields `slog.target`, `slog.module_path`, `slog.file`, `slog.line`, and `slog.column` with corresponding values from the slog call site.
+Specifically, the emitted log entries include the custom fields `slog.target`, `slog.module_path`, `slog.file`, `slog.line`, and `slog.column` with corresponding values from the slog call site. A field `slog.fields` will contain a comma-separated list of the possible [key value pairs](https://docs.rs/slog/latest/slog/trait.KV.html) supported in `slog` logging macros.
+
 
 Note that the "native" `filename` and `line_number` metadata attributes will never be available (and `target` will always be `slog`). This is due to the fact that `tracing` requires static metadata constructed at the original call site. The `tracing-log` adapter does provide these due to explicit support in `tracing`.

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("json tracing example");
 
-    slog::info!(slogger, "logged using slog"; "arg1" => "val1");
+    slog::info!(slogger, "logged using slog"; "arg1" => "val1", "arg2"=>"val2");
     nested::log_something(&slogger);
 
     log::info!("logged using plain log");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ struct TracingKvSerializer {
 
 #[cfg(feature = "kv")]
 impl TracingKvSerializer {
-    /// Return the serialized fields as a string. If empty, returns None
+    /// Returns the serialized fields as a string. If empty, returns `None`.
     fn as_str(&self) -> Option<&str> {
         self.storage
             .get(..self.storage.len().saturating_sub(1))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use tracing_core::{
 };
 
 #[cfg(feature = "kv")]
-/// An allocating serializer to use for serializing key-value pairs in a [`slog::Record`]
+/// An allocating serializer to use for serializing key-value pairs in a [`slog::Record`].
 #[derive(Default)]
 struct TracingKvSerializer {
     storage: String,


### PR DESCRIPTION
Hi @pnehrer , thanks for the useful crate! 

I recently used this crate in a project that made heavy use of the `slog` support for [key value pairs](https://docs.rs/slog/latest/slog/trait.KV.html) and added some basic support to this library for serializing those to a new field, `slog.fields` and thought I would contribute that change upstream in case it would be useful for others as well.

Feel free to decline this PR if you don't think this kind of addition makes sense here. I gated the new functionality behind a `kv` feature because it does have some slight allocation overhead per log generated if a key-value pair is in use. I made this feature opt-out but would be happy to swap that to opt-in.